### PR TITLE
Add `jetpack global update` to `jetpack help`

### DIFF
--- a/R/jetpack.R
+++ b/R/jetpack.R
@@ -823,6 +823,7 @@ run <- function() {
     jetpack global add <package>... [--remote=<remote>]...
     jetpack global remove <package>... [--remote=<remote>]...
     jetpack global update [<package>...] [--remote=<remote>]... [--verbose]
+    jetpack global update [--remote=<remote>]... [--verbose]
     jetpack global list"
 
     opts <- NULL


### PR DESCRIPTION
It seems like it would be good to document the “update all of my global packages” functionality in `jetpack -h`.