### PR TITLE
Add installation method from git to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ Install Jetpack
 install.packages("jetpack")
 ```
 
+Or install latest version from Github
+
+```r
+install.packages("devtools")
+library(devtools)
+install_github("anakane/jetpack")
+```
+
 ## How It Works
 
 Jetpack creates a `DESCRIPTION` file to store your project dependencies. It stores the specific version of each package in `packrat.lock`. This makes it possible to have a reproducible environment. You can edit dependencies in the `DESCRIPTION` file directly, but Jetpack provides functions to help with this.


### PR DESCRIPTION
Would it be helpful to add instructions to help people install the "bleeding edge" of jetpack? I think maybe the subtitle for the section that I added could be edited to encourage only the people who **need** the latest github version from downloading via github, but I would have found this helpful when I wanted `jetpack global update` to work.