### PR TITLE
load renv before running tests

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,6 @@
 library(testthat)
 library(jetpack)
 
+requireNamespace("renv", quietly = TRUE)
+
 test_check("jetpack")


### PR DESCRIPTION
This will give `renv` an opportunity to run some hooks on startup, which can be used to help ensure that `jetpack` passes tests when running reverse dependency checks for `renv` package submissions.